### PR TITLE
Implement Next.js login page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,25 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import { Providers } from "./providers";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Login App",
+  description: "Example login page",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from "@/components/LoginForm";
+
+export default function LoginPage() {
+  return (
+    <main className="flex items-center justify-center min-h-screen">
+      <LoginForm />
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main className="flex items-center justify-center min-h-screen">
+      <Link href="/login" className="text-blue-600 underline">
+        Go to Login
+      </Link>
+    </main>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { Provider } from "react-redux";
+import { store } from "@/lib/store";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { login } from "@/features/authSlice";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function LoginForm() {
+  const dispatch = useAppDispatch();
+  const { status, error } = useAppSelector((state) => state.auth);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    dispatch(login({ email, password }));
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="max-w-sm space-y-4">
+      <Input
+        placeholder="Email"
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <Input
+        placeholder="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <Button type="submit" disabled={status === "loading"}>
+        {status === "loading" ? "Logging in..." : "Log In"}
+      </Button>
+      {error && <p className="text-red-500">{error}</p>}
+    </form>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export function Button({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn(
+        "inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,14 @@
+import { InputHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+
+export function Input({ className, ...props }: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={cn(
+        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/features/authSlice.ts
+++ b/features/authSlice.ts
@@ -1,0 +1,52 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+
+export interface AuthState {
+  token: string | null;
+  status: "idle" | "loading" | "failed";
+  error: string | null;
+}
+
+const initialState: AuthState = {
+  token: null,
+  status: "idle",
+  error: null,
+};
+
+export const login = createAsyncThunk(
+  "auth/login",
+  async ({ email, password }: { email: string; password: string }) => {
+    const res = await fetch("http://3.9.160.137:5000/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ email, password }),
+    });
+    if (!res.ok) {
+      throw new Error("Login failed");
+    }
+    const data = await res.json();
+    return data.token as string;
+  }
+);
+
+const authSlice = createSlice({
+  name: "auth",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(login.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(login.fulfilled, (state, action) => {
+        state.status = "idle";
+        state.token = action.payload;
+      })
+      .addCase(login.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.error.message || "Unknown error";
+      });
+  },
+});
+
+export default authSlice.reducer;

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import type { RootState, AppDispatch } from "./store";
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from "@reduxjs/toolkit";
+import authReducer from "@/features/authSlice";
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat" />
+
+// NOTE: This file should not be edited

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "login-page",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.13",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    },
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project configuration
- add Tailwind and PostCSS setup
- create Redux store and auth slice
- build LoginForm component with ShadCN-style UI
- wire login page and root layout using Redux provider

## Testing
- `git status -s`


------
https://chatgpt.com/codex/tasks/task_e_6854453ba60c8323955b426cf31f8408