### PR TITLE
Add basic dashboard page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,21 @@
+export default function DashboardPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-3xl font-bold mb-6">Dashboard</h1>
+      <div className="grid gap-6 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        <div className="rounded-lg border p-4 shadow">
+          <h2 className="font-semibold text-lg mb-2">Health &amp; Safety Management</h2>
+          <p className="text-sm text-gray-600">Overview of compliance status.</p>
+        </div>
+        <div className="rounded-lg border p-4 shadow">
+          <h2 className="font-semibold text-lg mb-2">Compliance Management</h2>
+          <p className="text-sm text-gray-600">Track your compliance tasks.</p>
+        </div>
+        <div className="rounded-lg border p-4 shadow">
+          <h2 className="font-semibold text-lg mb-2">My Account</h2>
+          <p className="text-sm text-gray-600">Manage your user details.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,12 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <main className="flex items-center justify-center min-h-screen">
+    <main className="flex items-center justify-center gap-4 min-h-screen">
       <Link href="/login" className="text-blue-600 underline">
         Go to Login
+      </Link>
+      <Link href="/dashboard" className="text-blue-600 underline">
+        Go to Dashboard
       </Link>
     </main>
   );


### PR DESCRIPTION
## Summary
- add a new `/dashboard` route with a simple grid layout
- update homepage to link to dashboard

## Testing
- `npm install` *(fails: 403 Forbidden due to lack of network access)*
- `npm run build` *(fails: next not found without deps)*

------
https://chatgpt.com/codex/tasks/task_e_68544bb86f4c83238b9752bd9bee1056